### PR TITLE
Add android hardware rendering option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
  <a href="https://www.npmjs.com/package/@candlefinance%2Ffaster-image">
   <img src="https://img.shields.io/npm/dm/@candlefinance%2Ffaster-image" alt="npm downloads" />
 </a>
-  <a alt="discord users online" href="https://discord.gg/qnAgjxhg6n" 
+  <a alt="discord users online" href="https://discord.gg/qnAgjxhg6n"
   target="_blank"
   rel="noopener noreferrer">
     <img alt="discord users online" src="https://img.shields.io/discord/986610142768406548?label=Discord&logo=discord&logoColor=white&cacheSeconds=3600"/>
@@ -79,7 +79,8 @@ import { FasterImageView } from '@candlefinance/faster-image';
 | progressiveLoadingEnabled | boolean  | false                    | Progressively load images (iOS only)                                                                 |
 | onError                   | function |                          | The function to call when an error occurs. The error is passed as the first argument of the function |
 | onSuccess                 | function |                          | The function to call when the image is successfully loaded                                           |
-| grayscale                 | number |     0                     | Filter or transformation that converts the image into shades of gray (0-1).                                         |
+| grayscale                 | number   | 0                        | Filter or transformation that converts the image into shades of gray (0-1).                          |
+| allowHardware             | boolean  | true                     | Allow hardware rendering (Android only)                                                              |
 
 ## Contributing
 

--- a/android/src/main/java/com/candlefinance/fasterimage/FasterImageViewManager.kt
+++ b/android/src/main/java/com/candlefinance/fasterimage/FasterImageViewManager.kt
@@ -58,6 +58,7 @@
         val cachePolicy = options.getString("cachePolicy")
         val failureImage = options.getString("failureImage")
         val grayscale = if (options.hasKey("grayscale")) options.getDouble("grayscale") else 0.0
+        val allowHardware = if (options.hasKey("allowHardware")) options.getBoolean("allowHardware") else true
 
         if (borderRadius != 0.0) {
           setViewBorderRadius(view, borderRadius.toInt())
@@ -118,6 +119,7 @@
           .fallback(failureDrawable ?: drawablePlaceholder)
           .memoryCachePolicy(if (cachePolicy == "memory") CachePolicy.ENABLED else CachePolicy.DISABLED)
           .diskCachePolicy(if (cachePolicy == "discWithCacheControl" || cachePolicy == "discNoCacheControl") CachePolicy.ENABLED else CachePolicy.DISABLED)
+          .allowHardware(allowHardware)
           .build()
 
           imageLoader.enqueue(request)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,6 +34,8 @@ export type AndroidImageResizeMode =
  * @property {boolean} [progressiveLoadingEnabled] - Enable progressive loading, defaults to false
  * @property {('memory' | 'discWithCacheControl' | 'discNoCacheControl')} [cachePolicy] - Cache [policy](https://kean-docs.github.io/nuke/documentation/nuke/imagepipeline), defaults to 'memory'. 'discWithCacheControl' will cache the image in the disc and use the cache control headers to determine if the image should be re-fetched. 'discNoCacheControl' will cache the image in the disc and never re-fetch it.
  * @property {number} [borderRadius] - Border radius of the image
+ * @property {number} [grayscale] - Grayscale value of the image, 0-1
+ * @property {boolean} [allowHardware] - Allow hardware rendering, defaults to true (Android only)
  */
 export type ImageOptions = {
   blurhash?: string;
@@ -48,6 +50,7 @@ export type ImageOptions = {
   base64Placeholder?: string;
   url: string;
   grayscale?: number;
+  allowHardware?: boolean;
 };
 
 /**


### PR DESCRIPTION
We faced crashes on Android while using viewshot due to bitmap conversions. Setting hardware rendering to false helped. (https://github.com/coil-kt/coil/issues/159)