### PR TITLE
feat: handle base64 image urls android

### DIFF
--- a/android/src/main/java/com/candlefinance/fasterimage/FasterImageViewManager.kt
+++ b/android/src/main/java/com/candlefinance/fasterimage/FasterImageViewManager.kt
@@ -73,10 +73,19 @@
        val drawablePlaceholder: Drawable? = base64Placeholder?.let { getDrawableFromBase64(it, view) }
        val failureDrawable: Drawable? = failureImage?.let { getDrawableFromBase64(it, view) }
        val thumbHashDrawable = thumbHash?.let { makeThumbHash(view, it) }
+      
+       // Handle base64 image sources
+       val imageData = url?.let {
+         if (it.startsWith("data:image")) {
+           getDrawableFromBase64(it.substringAfter("base64,"), view)
+         } else {
+           it // Use the URL directly
+         }
+       }
 
        val imageLoader = view.context.imageLoader
        val request = ImageRequest.Builder(view.context)
-          .data(url)
+          .data(imageData)
           .target(
             onStart = { placeholder ->
               view.setImageDrawable(placeholder)


### PR DESCRIPTION
This PR adds support for base64 images in the URL/source on android. 

This already works on iOS, however on android it is not supported. By handling the case where the source is a base64 image the consistency of the API is improved.  