### PR TITLE
feat: non-uniform border radii

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ await clearCache();
 | cachePolicy               | string                 | memory                   | The cache policy of the image                                                                        |
 | transitionDuration        | number                 | 0.75 (iOS) Android (100) | The transition duration of the image                                                                 |
 | borderRadius              | number                 | 0                        | border radius of image                                                                               |
-| borderTopLeftRadius       | number                 | 0                        | top left border radius of image (Android only)                                                       |
-| borderTopRightRadius      | number                 | 0                        | top right border radius of image (Android only)                                                      |
-| borderBottomLeftRadius    | number                 | 0                        | bottom left border radius of image (Android only)                                                    |
-| borderBottomRightRadius   | number                 | 0                        | bottom right border radius of image (Android only)                                                   |
+| borderTopLeftRadius       | number                 | 0                        | top left border radius of image                                                                      |
+| borderTopRightRadius      | number                 | 0                        | top right border radius of image                                                                     |
+| borderBottomLeftRadius    | number                 | 0                        | bottom left border radius of image                                                                   |
+| borderBottomRightRadius   | number                 | 0                        | bottom right border radius of image                                                                  |
 | failureImage              | string                 |                          | If the image fails to download this will be set (blurhash, thumbhash, base64)                        |
 | progressiveLoadingEnabled | boolean                | false                    | Progressively load images (iOS only)                                                                 |
 | onError                   | function               |                          | The function to call when an error occurs. The error is passed as the first argument of the function |

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ await clearCache();
 | cachePolicy               | string                 | memory                   | The cache policy of the image                                                                        |
 | transitionDuration        | number                 | 0.75 (iOS) Android (100) | The transition duration of the image                                                                 |
 | borderRadius              | number                 | 0                        | border radius of image                                                                               |
+| borderTopLeftRadius       | number                 | 0                        | top left border radius of image (Android only)                                                       |
+| borderTopRightRadius      | number                 | 0                        | top right border radius of image (Android only)                                                      |
+| borderBottomLeftRadius    | number                 | 0                        | bottom left border radius of image (Android only)                                                    |
+| borderBottomRightRadius   | number                 | 0                        | bottom right border radius of image (Android only)                                                   |
 | failureImage              | string                 |                          | If the image fails to download this will be set (blurhash, thumbhash, base64)                        |
 | progressiveLoadingEnabled | boolean                | false                    | Progressively load images (iOS only)                                                                 |
 | onError                   | function               |                          | The function to call when an error occurs. The error is passed as the first argument of the function |

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -65,7 +65,7 @@ export default function App() {
               borderTopLeftRadius:
                 Platform.OS === 'android' ? size : (size - 16) / 2,
               borderBottomRightRadius:
-                Platform.OS === 'android' ? size : (size - 16) / 2,
+                Platform.OS === 'android' ? size / 1.5 : (size - 16) / 3,
               cachePolicy: 'discWithCacheControl',
               showActivityIndicator: true,
               base64Placeholder:

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -62,8 +62,10 @@ export default function App() {
             }}
             source={{
               transitionDuration: 0.3,
-              borderRadius:
-                Platform.OS === 'android' ? size * 2 : (size - 16) / 2,
+              borderTopLeftRadius:
+                Platform.OS === 'android' ? size : (size - 16) / 2,
+              borderBottomRightRadius:
+                Platform.OS === 'android' ? size : (size - 16) / 2,
               cachePolicy: 'discWithCacheControl',
               showActivityIndicator: true,
               base64Placeholder:
@@ -83,7 +85,8 @@ const styles = StyleSheet.create({
   image: {
     width: size - 16,
     height: size - 16,
-    borderRadius: (size - 16) / 2,
+    borderTopLeftRadius: (size - 16) / 2,
+    borderBottomRightRadius: (size - 16) / 2,
     overflow: 'hidden',
     backgroundColor: 'white',
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,10 @@ export type AndroidImageResizeMode =
  * @property {boolean} [progressiveLoadingEnabled] - Enable progressive loading, defaults to false
  * @property {('memory' | 'discWithCacheControl' | 'discNoCacheControl')} [cachePolicy] - Cache [policy](https://kean-docs.github.io/nuke/documentation/nuke/imagepipeline), defaults to 'memory'. 'discWithCacheControl' will cache the image in the disc and use the cache control headers to determine if the image should be re-fetched. 'discNoCacheControl' will cache the image in the disc and never re-fetch it.
  * @property {number} [borderRadius] - Border radius of the image
+ * @property {number} [borderTopLeftRadius] - Top left border radius of the image
+ * @property {number} [borderTopRightRadius] - Top right border radius of the image
+ * @property {number} [borderBottomLeftRadius] - Bottom left border radius of the image
+ * @property {number} [borderBottomRightRadius] - Bottom right border radius of the image
  * @property {number} [grayscale] - Grayscale value of the image, 0-1
  * @property {boolean} [allowHardware] - Allow hardware rendering, defaults to true (Android only)
  */
@@ -49,6 +53,10 @@ export type ImageOptions = {
   thumbhash?: string;
   resizeMode?: IOSImageResizeMode | AndroidImageResizeMode;
   borderRadius?: number;
+  borderTopLeftRadius?: number;
+  borderTopRightRadius?: number;
+  borderBottomLeftRadius?: number;
+  borderBottomRightRadius?: number;
   showActivityIndicator?: boolean;
   transitionDuration?: number;
   cachePolicy?: 'memory' | 'discWithCacheControl' | 'discNoCacheControl';


### PR DESCRIPTION
## I'm submitting a ...

- [x] feature request

## Description

Introduces the ability to set non-uniform border radii for both Android & iOS images.
This feature allows developers to specify different border radius values for different corner of a image, enhancing design flexibility.

Fixes #6

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Tested on
- iPhone 15 Pro Max (simulator), iOS 17.4
- Google Pixel 6 (device), Android 14