### PR TITLE
fix: add namespace into build.gradle.android for RN ^0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,11 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    // Check AGP version for backward compatibility reasons
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+      namespace = "com.candlefinance.fasterimage"
+    }
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {


### PR DESCRIPTION
hello

this pull request is about to issue that android environment setting

react-native team has decide to don't use package name in AndroidManifest.xml from ^0.73 version,
instead, use namespace property in build.gradle

check this out
https://github.com/react-native-community/discussions-and-proposals/issues/671

___
++ you have name space in app/build.gradle for example , but android/build.gradle has not namespace
