### PR TITLE
feat: ignoreQueryParamsForCacheKey image option (iOS & Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ await clearCache();
 | onError                   | function               |                          | The function to call when an error occurs. The error is passed as the first argument of the function |
 | onSuccess                 | function               |                          | The function to call when the image is successfully loaded                                           |
 | grayscale                 | number                 | 0                        | Filter or transformation that converts the image into shades of gray (0-1).                          |
+| ignoreQueryParamsForCacheKey | boolean | false | Ignore URL query parameters in cache keys |
 | allowHardware             | boolean                | true                     | Allow hardware rendering (Android only)                                                              |
 | headers                   | Record<string, string> | undefined                | Pass in headers                                                                                      |
 | accessibilityLabel        | string                 | undefined                | accessibility label                                                                                  |

--- a/android/src/main/java/com/candlefinance/fasterimage/FasterImageViewManager.kt
+++ b/android/src/main/java/com/candlefinance/fasterimage/FasterImageViewManager.kt
@@ -98,7 +98,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
         val headers = options.getMap("headers")
         val ignoreQueryParamsForCacheKey = if (options.hasKey("ignoreQueryParamsForCacheKey")) options.getBoolean("ignoreQueryParamsForCacheKey") else false
 
-       val borderRadii = BorderRadii(
+        val borderRadii = BorderRadii(
           uniform = if (options.hasKey("borderRadius")) options.getDouble("borderRadius") else 0.0,
           topLeft = if (options.hasKey("borderTopLeftRadius")) options.getDouble("borderTopLeftRadius") else 0.0,
           topRight = if (options.hasKey("borderTopRightRadius")) options.getDouble("borderTopRightRadius") else 0.0,
@@ -283,7 +283,6 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
       )
     }
   }
-
 
   object ThumbHash {
     /**

--- a/ios/FasterImageViewManager.swift
+++ b/ios/FasterImageViewManager.swift
@@ -140,6 +140,7 @@ final class FasterImageView: UIView {
                 if let url = URL(string: options.url) {
                     var urlRequestFromOptions = URLRequest(url: url)
                     urlRequestFromOptions.allHTTPHeaderFields = options.headers
+
                     urlRequest = urlRequestFromOptions
 
                     if ignoreQueryParamsForCacheKey {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,7 @@ export type AndroidImageResizeMode =
  * @property {number} [borderBottomRightRadius] - Bottom right border radius of the image
  * @property {number} [grayscale] - Grayscale value of the image, 0-1
  * @property {boolean} [allowHardware] - Allow hardware rendering, defaults to true (Android only)
+ * @property {boolean} [ignoreQueryParamsForCacheKey] - Ignore query params for cache key, defaults to false
  */
 export type ImageOptions = {
   blurhash?: string;
@@ -70,6 +71,7 @@ export type ImageOptions = {
   headers?: Record<string, string>;
   grayscale?: number;
   allowHardware?: boolean;
+  ignoreQueryParamsForCacheKey?: boolean;
 };
 
 /**


### PR DESCRIPTION
Ignores URL query parameters for cache keys when the new option is set to true, defaults to false.

This is needed for example when downloading images using S3 presigned URL's that include a signature that changes between requests preventing the images from being found in the cache.

Also fixes the merge error in FasterImageViewManager.kt which came from commit 86a23fd2c9da28147fc3bcb3cf8be78f57a5d327