### PR TITLE
fix: ensure callbacks execute on cache hits by dispatching to main queue

### DIFF
--- a/ios/FasterImageViewManager.swift
+++ b/ios/FasterImageViewManager.swift
@@ -74,7 +74,9 @@ final class FasterImageView: UIView {
         lazyImageView.pipeline = .shared
         lazyImageView.priority = .high
         lazyImageView.onCompletion = { [weak self] result in
-            self?.completionHandler(with: result)
+            DispatchQueue.main.async {
+                self?.completionHandler(with: result)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #41 for iOS. Not familiar enough with Kotlin to fix on Android.