### PR TITLE
Add support for `colorMatrix` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ await prefetch(['https://picsum.photos/200/200?random=0'])
 | resizeMode                | string                 | contain                  | The resize mode of the image                                                                         |
 | thumbhash                 | string                 |                          | The thumbhash of the image as a base64 encoded string to show while loading (Android not tested)     |
 | blurhash                  | string                 |                          | The blurhash of the image to show while loading (iOS only)                                           |
-| showActivityIndicator     | boolean                | false (iOS only)         | Whether to show the UIActivityIndicatorView indicator when the image is loading   
+| showActivityIndicator     | boolean                | false (iOS only)         | Whether to show the UIActivityIndicatorView indicator when the image is loading
 | activityColor             | ColorValue             | undefined (iOS only)     | Activity indicator color. Changed default activity indicator color. Only hex supported     |
 | base64Placeholder         | string                 |                          | The base64 encoded placeholder image to show while the image is loading                              |
 | cachePolicy               | string                 | memory                   | The cache policy of the image                                                                        |
@@ -97,6 +97,7 @@ await prefetch(['https://picsum.photos/200/200?random=0'])
 | onError                   | function               |                          | The function to call when an error occurs. The error is passed as the first argument of the function |
 | onSuccess                 | function               |                          | The function to call when the image is successfully loaded                                           |
 | grayscale                 | number                 | 0                        | Filter or transformation that converts the image into shades of gray (0-1).                          |
+| colorMatrix               | number[][]             |                          | Color matrix that is applied to image                                                                |
 | ignoreQueryParamsForCacheKey | boolean | false | Ignore URL query parameters in cache keys |
 | allowHardware             | boolean                | true                     | Allow hardware rendering (Android only)                                                              |
 | headers                   | Record<string, string> | undefined                | Pass in headers                                                                                      |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,6 +46,7 @@ export type AndroidImageResizeMode =
  * @property {number} [borderBottomLeftRadius] - Bottom left border radius of the image
  * @property {number} [borderBottomRightRadius] - Bottom right border radius of the image
  * @property {number} [grayscale] - Grayscale value of the image, 0-1
+ * @property {number[][]} [colorMatrix] - Color matrix to apply to the image
  * @property {boolean} [allowHardware] - Allow hardware rendering, defaults to true (Android only)
  * @property {boolean} [ignoreQueryParamsForCacheKey] - Ignore query params for cache key, defaults to false
  * @property {'veryLow' | 'low' | 'normal' | 'high' | 'veryHigh'} [priority] - Set Image's loading priority, defaults to 'normal' (iOS only)
@@ -75,6 +76,7 @@ export type ImageOptions = {
   url: string;
   headers?: Record<string, string>;
   grayscale?: number;
+  colorMatrix?: number[][];
   allowHardware?: boolean;
   ignoreQueryParamsForCacheKey?: boolean;
   priority?: 'veryLow' | 'low' | 'normal' | 'high' | 'veryHigh';


### PR DESCRIPTION
Add support for passing `colorMatrix` prop to enable adding filters to images.
Color matrix should be an array 4x5, following [svg color matrix format](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feColorMatrix), as well as [Android](https://developer.android.com/reference/android/graphics/ColorMatrix).
On iOS the [required format for matrix](https://developer.apple.com/library/archive/documentation/GraphicsImaging/Reference/CoreImageFilterReference/index.html#//apple_ref/doc/filter/ci/CIColorMatrix) is 5x4, so for consistency sake, the resolving of last row is done on native side.