### PR TITLE
feat: Support `contentPosition` for image alignment

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,16 @@ export type AndroidImageResizeMode =
   | 'top'
   | 'bottom';
 
+export type ContentPosition =
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'topLeft'
+  | 'topRight'
+  | 'bottomLeft'
+  | 'bottomRight';
+
 /*
  * @property {string} url - URL of the image **required**
  * @property {string} [base64Placeholder] - Base64 encoded placeholder image
@@ -40,6 +50,7 @@ export type AndroidImageResizeMode =
  * @property {string} [failureImage] - Image to show when the image fails to load, pass blurhash, thumbhash or base64 encoded image
  * @property {boolean} [progressiveLoadingEnabled] - Enable progressive loading, defaults to false
  * @property {('memory' | 'discWithCacheControl' | 'discNoCacheControl')} [cachePolicy] - Cache [policy](https://kean-docs.github.io/nuke/documentation/nuke/imagepipeline), defaults to 'memory'. 'discWithCacheControl' will cache the image in the disc and use the cache control headers to determine if the image should be re-fetched. 'discNoCacheControl' will cache the image in the disc and never re-fetch it.
+ * @property {ContentPosition} [contentPosition] - Position of the image content within the image view
  * @property {number} [borderRadius] - Border radius of the image
  * @property {number} [borderTopLeftRadius] - Top left border radius of the image
  * @property {number} [borderTopRightRadius] - Top right border radius of the image
@@ -70,6 +81,7 @@ export type ImageOptions = {
     | 'discWithCacheControl'
     | 'discNoCacheControl'
     | 'memoryAndDisc';
+  contentPosition?: ContentPosition;
   failureImage?: string;
   progressiveLoadingEnabled?: boolean;
   base64Placeholder?: string;


### PR DESCRIPTION
Resolves #75

I'd like to point out the one `TODO` remark on the Kotlin side:

```
I can't find a way to support contentposition without overriding the scaleType
```

I tried to loosely base this off of `expo-image`'s [implementation](https://github.com/expo/expo/blob/main/packages/expo-image/ios/ContentPosition.swift). I recorded a brief demo, as well:


https://github.com/user-attachments/assets/d2f3d635-1fc6-45d4-9f57-750bf141165a


On an unrelated note, I was able to get the iOS build sorted. So I'll revisit my other PR.