### PR TITLE
Add color space configuration feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ yarn add @candlefinance/faster-image
 ## Usage
 
 ```js
-import { FasterImageView, clearCache, prefetch } from '@candlefinance/faster-image';
+import { FasterImageView, clearCache, prefetch, setColorSpace } from '@candlefinance/faster-image';
 
 <FasterImageView
   style={styles.image}
@@ -69,7 +69,10 @@ import { FasterImageView, clearCache, prefetch } from '@candlefinance/faster-ima
 await clearCache();
 
 // Prefetch
-await prefetch(['https://picsum.photos/200/200?random=0'])
+await prefetch(['https://picsum.photos/200/200?random=0']);
+
+// Set color space
+await setColorSpace('sRGB');
 
 // Prefetch with headers
 const token = 'your-token';

--- a/ios/FasterImageViewManager.m
+++ b/ios/FasterImageViewManager.m
@@ -12,4 +12,6 @@ RCT_EXTERN_METHOD(clearCache:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromis
 
 RCT_EXTERN_METHOD(prefetch:(NSArray *)sources withOptions:(nullable NSDictionary *)options withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setColorSpace:(NSString *)colorSpaceName withResolver:(RCTPromiseResolveBlock)resolve withRejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/FasterImageViewManager.swift
+++ b/ios/FasterImageViewManager.swift
@@ -47,6 +47,39 @@ final class FasterImageViewManager: RCTViewManager {
       prefetcher.startPrefetching(with: imageRequests)
       resolve(true)
   }
+  
+  @objc(setColorSpace:withResolver:withRejecter:)
+  func setColorSpace(_ colorSpaceName: String,
+                     resolve: @escaping RCTPromiseResolveBlock,
+                     reject: @escaping RCTPromiseRejectBlock) {
+    let cgColorSpace: CGColorSpace?
+    switch colorSpaceName.lowercased() {
+      case "srgb":
+        cgColorSpace = CGColorSpace(name: CGColorSpace.sRGB)
+      case "displayp3":
+        cgColorSpace = CGColorSpace(name: CGColorSpace.displayP3)
+      case "linearsrgb":
+        cgColorSpace = CGColorSpace(name: CGColorSpace.linearSRGB)
+      case "genericrgb":
+        cgColorSpace = CGColorSpaceCreateDeviceRGB()
+      default:
+        cgColorSpace = nil
+    }
+    
+    guard let colorSpace = cgColorSpace else {
+      reject("INVALID_COLOR_SPACE", "Failed to create color space: \(colorSpaceName)", nil)
+      return
+    }
+
+    let contextOptions: [CIContextOption: Any] = [
+      .workingColorSpace: colorSpace,
+      .outputColorSpace: colorSpace,
+      .priorityRequestLow: true
+    ]
+    
+    ImageProcessors.CoreImageFilter.context = CIContext(options: contextOptions)
+    resolve(true)
+  }
 }
 
 struct ContentPosition: Decodable {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -165,3 +165,15 @@ export const prefetch = (
     return FasterImageModule.prefetch(sources, options);
   }
 };
+
+export const setColorSpace = (colorSpace: 'sRGB' | 'displayP3' | 'linearSRGB' | 'genericRGB'): Promise<void> => {
+  if (Platform.OS === 'ios') {
+    const { FasterImageViewManager } = NativeModules;
+    return FasterImageViewManager.setColorSpace(colorSpace);
+  } 
+  
+  // Android: Color space configuration is not implemented
+  // Coil 2.4.0 doesn't have native colorSpace() support (available in Coil 3.x)
+  // Return resolved promise to maintain API consistency
+  return Promise.resolve();
+};


### PR DESCRIPTION
Added `setColorSpace` function needed on iOS as a way to configure the color space for image processing. 

This change was needed to ensure consistency when displaying images with color matrix filters across iOS, Android, and web platforms. Android defaults to sRGB color space, and achieving parity with this behavior was the primary motivation for this implementation.

**Changes:**

- **iOS Implementation:** Added `setColorSpace()` static method to `FasterImageViewManager` that configures the global `CIContext`. The initial approach was to pass `colorSpace` as a prop, but was unsuccessful because `CIContext` configuration must be set globally at initialization rather than per-image. Supports `sRGB`, `displayP3`, `linearSRGB`, and `genericRGB` color spaces.

- **Android Limitation:** Coil 2.4.0 does not expose `ImageLoader.Builder.colorSpace()` (available in Coil 3.x), preventing color space configuration at the loader level. Implementation would require a custom decoder component to apply the color space during decoding, which is more complex and less reliable than using the native API. The Android implementation could be revisited if/when upgrading to Coil 3.x.

Visual examples from example app show how the update looks on iOS:
<table>
<tr>
<td>
iOS, no filter, no color space
</td>
<td>
iOS, "bright" color matrix filter, no color space
</td>
<td>
iOS, "bright" color matrix filter, sRGB color space
</td>
</tr>
<tr>
<td>
<img height="700" alt="ios no filter no colorspace" src="https://github.com/user-attachments/assets/28142b28-6646-4a91-a190-aeeee3ce0166" />
</td>
<td>
<img height="700" alt="ios filter no colorspace" src="https://github.com/user-attachments/assets/3cd004f1-3170-4edc-b80d-73bcf3145d2f" />
</td>
<td>
<img height="700" alt="ios filter sgrb colorspace" src="https://github.com/user-attachments/assets/979269c2-d2f9-4f30-a891-7d6343e0b79f" />
</td>
</tr>
 </table>

<table>
<tr>
<td>
Android, no filter
</td>
<td>
Android, "bright" color matrix filter
</td>
</tr>
<tr>
<td>
<img height="700" alt="android no filter" src="https://github.com/user-attachments/assets/b832a053-3a4b-4cc8-85fc-ca40477b8f70" />
</td>
<td>
<img height="700" alt="android filter" src="https://github.com/user-attachments/assets/5c587518-1694-4842-b3fd-3a59c87b63e5" />
</td>
</tr>
 </table>